### PR TITLE
Move timeout to async_http_utils.request_with_retry

### DIFF
--- a/src/vuln_analysis/configs/config.yml
+++ b/src/vuln_analysis/configs/config.yml
@@ -26,6 +26,7 @@ functions:
     base_code_index_dir: .cache/am_cache/code_index
   cve_fetch_intel:
     _type: cve_fetch_intel
+    client_timeout: 15
   cve_process_sbom:
     _type: cve_process_sbom
   cve_check_vuln_deps :

--- a/src/vuln_analysis/data/input_messages/morpheus:23.11-runtime.json
+++ b/src/vuln_analysis/data/input_messages/morpheus:23.11-runtime.json
@@ -40,27 +40,6 @@
     "vulns": [
       {
         "vuln_id": "GHSA-3f63-hfp8-52jq"
-      },
-      {
-        "vuln_id": "CVE-2023-50782"
-      },
-      {
-        "vuln_id": "CVE-2023-36632"
-      },
-      {
-        "vuln_id": "CVE-2023-43804"
-      },
-      {
-        "vuln_id": "GHSA-cxfr-5q3r-2rc2"
-      },
-      {
-        "vuln_id": "GHSA-554w-xh4j-8w64"
-      },
-      {
-        "vuln_id": "GHSA-3ww4-gg4f-jr7f"
-      },
-      {
-        "vuln_id": "CVE-2023-51767"
       }
     ]
   }

--- a/src/vuln_analysis/functions/cve_fetch_intel.py
+++ b/src/vuln_analysis/functions/cve_fetch_intel.py
@@ -46,12 +46,12 @@ async def cve_fetch_intel(config: CVEFetchIntelConfig, builder: Builder):  # pyl
 
         async def _inner():
 
-            timeout = aiohttp.ClientTimeout(total=config.client_timeout)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with aiohttp.ClientSession() as session:
 
                 intel_retriever = IntelRetriever(session=session,
                                                  max_retries=config.max_retries,
-                                                 retry_on_client_errors=config.retry_on_client_errors)
+                                                 retry_on_client_errors=config.retry_on_client_errors,
+                                                 client_timeout=config.client_timeout)
 
                 intel_coros = [intel_retriever.retrieve(vuln_id=cve.vuln_id) for cve in message.input.scan.vulns]
 

--- a/src/vuln_analysis/utils/async_http_utils.py
+++ b/src/vuln_analysis/utils/async_http_utils.py
@@ -31,47 +31,66 @@ async def request_with_retry(session: aiohttp.ClientSession,
                              sleep_time: float = 0.1,
                              respect_retry_after_header: bool = True,
                              log_on_error=True,
-                             retry_on_client_errors=True) -> typing.AsyncIterator[aiohttp.ClientResponse]:
+                             retry_on_client_errors=True,
+                             client_timeout: float | None = None) -> typing.AsyncIterator[aiohttp.ClientResponse]:
     """
     Async version of `http_utils.request_with_retry`
     """
     assert not request_kwargs.get('raise_for_status'), "raise_for_status is incompatible with `request_with_retry`"
-    try_count = 0
-    done = False
-    while try_count <= max_retries and not done:
-        response = None
-        response_headers = {}
+
+    async def _retry_loop():
+        try_count = 0
+        done = False
+        while try_count <= max_retries and not done:
+            response = None
+            response_headers = {}
+            try:
+                async with session.request(**request_kwargs) as response:
+                    response_headers = response.headers
+                    response.raise_for_status()
+                    yield response
+                    done = True
+            except Exception as e:
+                try_count += 1
+
+                if try_count >= max_retries:
+                    if (log_on_error):
+                        logger.error("Failed requesting %s after %d retries: %s", request_kwargs['url'], max_retries, e)
+                    raise e
+
+                actual_sleep_time = (2**(try_count - 1)) * sleep_time
+
+                if respect_retry_after_header and 'Retry-After' in response_headers:
+                    actual_sleep_time = max(int(response_headers["Retry-After"]), actual_sleep_time)
+                elif respect_retry_after_header and 'X-RateLimit-Reset' in response_headers:
+                    actual_sleep_time = max(int(response_headers["X-RateLimit-Reset"]) - time.time(), actual_sleep_time)
+                elif not retry_on_client_errors and response.status < 500:
+                    raise e
+
+                logger.warning("Error requesting [%d/%d]: (Retry %.1f sec) %s: %s",
+                               try_count,
+                               max_retries,
+                               actual_sleep_time,
+                               request_kwargs['url'],
+                               e)
+
+                await asyncio.sleep(actual_sleep_time)
+
+    # Apply client timeout if specified
+    if client_timeout is not None:
         try:
-            async with session.request(**request_kwargs) as response:
-                response_headers = response.headers
-                response.raise_for_status()
-                yield response
-                done = True
-        except Exception as e:
-            try_count += 1
-
-            if try_count >= max_retries:
-                if (log_on_error):
-                    logger.error("Failed requesting %s after %d retries: %s", request_kwargs['url'], max_retries, e)
-                raise e
-
-            actual_sleep_time = (2**(try_count - 1)) * sleep_time
-
-            if respect_retry_after_header and 'Retry-After' in response_headers:
-                actual_sleep_time = max(int(response_headers["Retry-After"]), actual_sleep_time)
-            elif respect_retry_after_header and 'X-RateLimit-Reset' in response_headers:
-                actual_sleep_time = max(int(response_headers["X-RateLimit-Reset"]) - time.time(), actual_sleep_time)
-            elif not retry_on_client_errors and response.status < 500:
-                raise e
-
-            logger.warning("Error requesting [%d/%d]: (Retry %.1f sec) %s: %s",
-                           try_count,
-                           max_retries,
-                           actual_sleep_time,
-                           request_kwargs['url'],
-                           e)
-
-            await asyncio.sleep(actual_sleep_time)
+            async with asyncio.timeout(client_timeout):
+                async for response in _retry_loop():
+                    yield response
+        except asyncio.TimeoutError:
+            if log_on_error:
+                logger.warning("Request with retry timed out after %.1f seconds: %s",
+                               client_timeout,
+                               request_kwargs['url'])
+            raise
+    else:
+        async for response in _retry_loop():
+            yield response
 
 
 _T = typing.TypeVar('_T')

--- a/src/vuln_analysis/utils/clients/first_client.py
+++ b/src/vuln_analysis/utils/clients/first_client.py
@@ -37,14 +37,16 @@ class FirstClient(IntelClient):
                  retry_count: int = 10,
                  sleep_time: float = 0.1,
                  respect_retry_after_header: bool = True,
-                 retry_on_client_errors: bool = True):
+                 retry_on_client_errors: bool = True,
+                 client_timeout: float | None = None):
 
         super().__init__(session=session,
                          base_url=base_url or os.environ.get('FIRST_BASE_URL'),
                          retry_count=retry_count,
                          sleep_time=sleep_time,
                          respect_retry_after_header=respect_retry_after_header,
-                         retry_on_client_errors=retry_on_client_errors)
+                         retry_on_client_errors=retry_on_client_errors,
+                         client_timeout=client_timeout)
 
         self._headers = {'Accept': 'application/json'}
 

--- a/src/vuln_analysis/utils/clients/ghsa_client.py
+++ b/src/vuln_analysis/utils/clients/ghsa_client.py
@@ -41,13 +41,15 @@ class GHSAClient(IntelClient):
                  retry_count: int = 10,
                  sleep_time: float = 0.1,
                  respect_retry_after_header: bool = True,
-                 retry_on_client_errors: bool = True):
+                 retry_on_client_errors: bool = True,
+                 client_timeout: float | None = None):
         super().__init__(session=session,
                          base_url=base_url or os.environ.get('GHSA_BASE_URL'),
                          retry_count=retry_count,
                          sleep_time=sleep_time,
                          respect_retry_after_header=respect_retry_after_header,
-                         retry_on_client_errors=retry_on_client_errors)
+                         retry_on_client_errors=retry_on_client_errors,
+                         client_timeout=client_timeout)
 
         self._api_key = api_key or os.environ.get('GHSA_API_KEY', None)
 

--- a/src/vuln_analysis/utils/clients/intel_client.py
+++ b/src/vuln_analysis/utils/clients/intel_client.py
@@ -30,7 +30,8 @@ class IntelClient:
                  retry_count: int = 10,
                  sleep_time: float = 0.1,
                  respect_retry_after_header: bool = True,
-                 retry_on_client_errors: bool = True):
+                 retry_on_client_errors: bool = True,
+                 client_timeout: float | None = None):
 
         if (session is None):
             session = aiohttp.ClientSession()
@@ -45,6 +46,7 @@ class IntelClient:
         self._sleep_time = sleep_time
         self._respect_retry_after_header = respect_retry_after_header
         self._retry_on_client_errors = retry_on_client_errors
+        self._client_timeout = client_timeout
 
     @classmethod
     @abstractmethod
@@ -82,6 +84,7 @@ class IntelClient:
                                       sleep_time=self._sleep_time,
                                       respect_retry_after_header=self._respect_retry_after_header,
                                       log_on_error=log_on_error,
-                                      retry_on_client_errors=self._retry_on_client_errors) as response:
+                                      retry_on_client_errors=self._retry_on_client_errors,
+                                      client_timeout=self._client_timeout) as response:
 
             return await response.json()

--- a/src/vuln_analysis/utils/clients/nvd_client.py
+++ b/src/vuln_analysis/utils/clients/nvd_client.py
@@ -21,12 +21,11 @@ import aiohttp
 from bs4 import BeautifulSoup
 
 from vuln_analysis.data_models.cve_intel import CveIntelNvd
-
 from vuln_analysis.utils.async_http_utils import request_with_retry
+from vuln_analysis.utils.clients.intel_client import IntelClient
 from vuln_analysis.utils.intel_utils import parse
 from vuln_analysis.utils.intel_utils import parse_config_vendors
 from vuln_analysis.utils.url_utils import url_join
-from vuln_analysis.utils.clients.intel_client import IntelClient
 
 logger = logging.getLogger(__name__)
 
@@ -51,14 +50,16 @@ class NVDClient(IntelClient):
                  retry_count: int = 10,
                  sleep_time: float = 0.1,
                  respect_retry_after_header: bool = True,
-                 retry_on_client_errors: bool = True):
+                 retry_on_client_errors: bool = True,
+                 client_timeout: float | None = None):
 
         super().__init__(session=session,
                          base_url=base_url or os.environ.get('NVD_BASE_URL'),
                          retry_count=retry_count,
                          sleep_time=sleep_time,
                          respect_retry_after_header=respect_retry_after_header,
-                         retry_on_client_errors=retry_on_client_errors)
+                         retry_on_client_errors=retry_on_client_errors,
+                         client_timeout=client_timeout)
 
         self._api_key = api_key or os.environ.get('NVD_API_KEY', None)
 

--- a/src/vuln_analysis/utils/clients/rhsa_client.py
+++ b/src/vuln_analysis/utils/clients/rhsa_client.py
@@ -37,14 +37,16 @@ class RHSAClient(IntelClient):
                  retry_count: int = 10,
                  sleep_time: float = 0.1,
                  respect_retry_after_header: bool = True,
-                 retry_on_client_errors: bool = True):
+                 retry_on_client_errors: bool = True,
+                 client_timeout: float | None = None):
 
         super().__init__(session=session,
                          base_url=base_url or os.environ.get('RHSA_BASE_URL'),
                          retry_count=retry_count,
                          sleep_time=sleep_time,
                          respect_retry_after_header=respect_retry_after_header,
-                         retry_on_client_errors=retry_on_client_errors)
+                         retry_on_client_errors=retry_on_client_errors,
+                         client_timeout=client_timeout)
 
     @classmethod
     def default_base_url(cls) -> str:

--- a/src/vuln_analysis/utils/clients/ubuntu_client.py
+++ b/src/vuln_analysis/utils/clients/ubuntu_client.py
@@ -35,14 +35,16 @@ class UbuntuClient(IntelClient):
                  retry_count: int = 10,
                  sleep_time: float = 0.1,
                  respect_retry_after_header: bool = True,
-                 retry_on_client_errors: bool = True):
+                 retry_on_client_errors: bool = True,
+                 client_timeout: float | None = None):
 
         super().__init__(session=session,
                          base_url=base_url or os.environ.get('UBUNTU_BASE_URL'),
                          retry_count=retry_count,
                          sleep_time=sleep_time,
                          respect_retry_after_header=respect_retry_after_header,
-                         retry_on_client_errors=retry_on_client_errors)
+                         retry_on_client_errors=retry_on_client_errors,
+                         client_timeout=client_timeout)
 
     @classmethod
     def default_base_url(cls) -> str:

--- a/src/vuln_analysis/utils/intel_retriever.py
+++ b/src/vuln_analysis/utils/intel_retriever.py
@@ -45,32 +45,39 @@ class IntelRetriever:
                  ghsa_api_key: str | None = None,
                  lang_code: str = 'en',
                  max_retries: int = 10,
-                 retry_on_client_errors: bool = True):
+                 retry_on_client_errors: bool = True,
+                 client_timeout: float | None = None):
         """
         Initialize the NISTCVERetriever with URL templates for vulnerability and CVE details.
         """
 
         # Create a shared session object for all requests
         self._session = session
+        self._client_timeout = client_timeout
 
         self._nvd_client = NVDClient(api_key=os.environ.get('NVD_API_KEY', nist_api_key),
                                      session=self._session,
                                      lang_code=lang_code,
                                      retry_count=max_retries,
-                                     retry_on_client_errors=retry_on_client_errors)
+                                     retry_on_client_errors=retry_on_client_errors,
+                                     client_timeout=client_timeout)
         self._first_client = FirstClient(session=self._session,
                                          retry_count=max_retries,
-                                         retry_on_client_errors=retry_on_client_errors)
+                                         retry_on_client_errors=retry_on_client_errors,
+                                         client_timeout=client_timeout)
         self._ghsa_client = GHSAClient(api_key=os.environ.get('GHSA_API_KEY', ghsa_api_key),
                                        session=self._session,
                                        retry_count=max_retries,
-                                       retry_on_client_errors=retry_on_client_errors)
+                                       retry_on_client_errors=retry_on_client_errors,
+                                       client_timeout=client_timeout)
         self._rhsa_client = RHSAClient(session=self._session,
                                        retry_count=max_retries,
-                                       retry_on_client_errors=retry_on_client_errors)
+                                       retry_on_client_errors=retry_on_client_errors,
+                                       client_timeout=client_timeout)
         self._ubuntu_client = UbuntuClient(session=self._session,
                                            retry_count=max_retries,
-                                           retry_on_client_errors=retry_on_client_errors)
+                                           retry_on_client_errors=retry_on_client_errors,
+                                           client_timeout=client_timeout)
 
     @asynccontextmanager
     async def _get_session(self, session: aiohttp.ClientSession | None = None):


### PR DESCRIPTION
This version moves timeout to `async_http_utils.request_with_retry` to control timeout at the overall intel fetch level instead of at individual request level. Example below shows it reaching the 15s timeout before the 10 retries are finished.
```
2025-08-07 15:06:37,276 - vuln_analysis.utils.document_embedding - INFO - Cache hit on VDB. Loading existing FAISS database: .cache/am_cache/vdb/code/ccf658f72228c497
2025-08-07 15:06:37,279 - faiss.loader - INFO - Loading faiss with AVX2 support.
2025-08-07 15:06:37,345 - faiss.loader - INFO - Successfully loaded faiss with AVX2 support.
2025-08-07 15:06:37,559 - vuln_analysis.utils.document_embedding - INFO - Cache hit on VDB. Loading existing FAISS database: .cache/am_cache/vdb/doc/c89fe6d707036daa
2025-08-07 15:06:38,051 - vuln_analysis.utils.async_http_utils - WARNING - Error requesting [1/10]: (Retry 0.1 sec) http://nginx-cache/ubuntu/doesnotexist/security/cves.json: 404, message='', url='http://nginx-cache/ubuntu/doesnotexist/security/cves.json?q=CVE-2023-50447'
2025-08-07 15:06:38,520 - vuln_analysis.utils.async_http_utils - WARNING - Error requesting [2/10]: (Retry 0.2 sec) http://nginx-cache/ubuntu/doesnotexist/security/cves.json: 404, message='', url='http://nginx-cache/ubuntu/doesnotexist/security/cves.json?q=CVE-2023-50447'
2025-08-07 15:06:39,020 - vuln_analysis.utils.async_http_utils - WARNING - Error requesting [3/10]: (Retry 0.4 sec) http://nginx-cache/ubuntu/doesnotexist/security/cves.json: 404, message='', url='http://nginx-cache/ubuntu/doesnotexist/security/cves.json?q=CVE-2023-50447'
2025-08-07 15:06:39,782 - vuln_analysis.utils.async_http_utils - WARNING - Error requesting [4/10]: (Retry 0.8 sec) http://nginx-cache/ubuntu/doesnotexist/security/cves.json: 404, message='', url='http://nginx-cache/ubuntu/doesnotexist/security/cves.json?q=CVE-2023-50447'
2025-08-07 15:06:40,948 - vuln_analysis.utils.async_http_utils - WARNING - Error requesting [5/10]: (Retry 1.6 sec) http://nginx-cache/ubuntu/doesnotexist/security/cves.json: 404, message='', url='http://nginx-cache/ubuntu/doesnotexist/security/cves.json?q=CVE-2023-50447'
2025-08-07 15:06:42,915 - vuln_analysis.utils.async_http_utils - WARNING - Error requesting [6/10]: (Retry 3.2 sec) http://nginx-cache/ubuntu/doesnotexist/security/cves.json: 404, message='', url='http://nginx-cache/ubuntu/doesnotexist/security/cves.json?q=CVE-2023-50447'
2025-08-07 15:06:46,463 - vuln_analysis.utils.async_http_utils - WARNING - Error requesting [7/10]: (Retry 6.4 sec) http://nginx-cache/ubuntu/doesnotexist/security/cves.json: 404, message='', url='http://nginx-cache/ubuntu/doesnotexist/security/cves.json?q=CVE-2023-50447'
2025-08-07 15:06:52,607 - vuln_analysis.utils.async_http_utils - WARNING - Request with retry timed out after 15.0 seconds: http://nginx-cache/ubuntu/doesnotexist/security/cves.json
2025-08-07 15:06:52,607 - vuln_analysis.utils.intel_retriever - ERROR - Error fetching Ubuntu security advisory for GHSA-3f63-hfp8-52jq : 
```